### PR TITLE
Allow `.` in Environment Variable Names

### DIFF
--- a/envparse.go
+++ b/envparse.go
@@ -135,11 +135,12 @@ func parseLine(ln []byte) ([]byte, []byte, error) {
 	for _, v := range key[1:] {
 		switch {
 		case v == '_':
+		case v == '.':
 		case v >= 'A' && v <= 'Z':
 		case v >= 'a' && v <= 'z':
 		case v >= '0' && v <= '9':
 		default:
-			return nil, nil, fmt.Errorf("key characters must be [A-Za-z0-9_] but found %q", v)
+			return nil, nil, fmt.Errorf("key characters must be [A-Za-z0-9_.] but found %q", v)
 		}
 	}
 

--- a/envparse_test.go
+++ b/envparse_test.go
@@ -105,6 +105,7 @@ func TestParseLine_OK(t *testing.T) {
 		{"EscapedUnicodeCombined", `U4="\u2318\uD83D\uDE01"`, "U4", "\U00002318\U0001F601"},
 		{"README.mdEscapedUnicode", `FOO="The template value\nmay have included\nsome newlines!\n\ud83d\udd25"`, "FOO", "The template value\nmay have included\nsome newlines!\n🔥"},
 		{"UnderscoreKey", "_=x' ' ", "_", "x "},
+		{"DottedKey", "FOO.BAR=x", "FOO.BAR", "x"},
 		{"README.md", `SOME_KEY = normal unquoted \text 'plus single quoted\' "\"double quoted " # EOL`, "SOME_KEY", `normal unquoted \text plus single quoted\ "double quoted `},
 		{"WindowsNewline", `w="\r\n"`, "w", "\r\n"},
 	}


### PR DESCRIPTION
From https://github.com/appc/spec/blob/master/spec/aci.md:

> environment (list of objects, optional) represents the app's environment variables (ACE can append). The listed objects must have two key-value pairs: name and value. The name must consist solely of letters, digits, and underscores '_' as outlined in IEEE Std 1003.1-2008, 2016 Edition, with practical considerations dictating that the name may also include periods '.' and hyphens '-'. The value is an arbitrary string. These values are not evaluated in any way, and no substitutions are made.

Dotted environment variables are frequently used as a part of the Spring Boot pattern. (re: ZD-6116)

See also [Nomad PR# 3760](https://github.com/hashicorp/nomad/pull/3760)