### PR TITLE
Allow `/` in Environment Variable Names

### DIFF
--- a/envparse.go
+++ b/envparse.go
@@ -136,11 +136,12 @@ func parseLine(ln []byte) ([]byte, []byte, error) {
 		switch {
 		case v == '_':
 		case v == '.':
+		case v == '/':
 		case v >= 'A' && v <= 'Z':
 		case v >= 'a' && v <= 'z':
 		case v >= '0' && v <= '9':
 		default:
-			return nil, nil, fmt.Errorf("key characters must be [A-Za-z0-9_.] but found %q", v)
+			return nil, nil, fmt.Errorf("key characters must be [A-Za-z0-9/_.] but found %q", v)
 		}
 	}
 

--- a/envparse_test.go
+++ b/envparse_test.go
@@ -106,6 +106,7 @@ func TestParseLine_OK(t *testing.T) {
 		{"README.mdEscapedUnicode", `FOO="The template value\nmay have included\nsome newlines!\n\ud83d\udd25"`, "FOO", "The template value\nmay have included\nsome newlines!\n🔥"},
 		{"UnderscoreKey", "_=x' ' ", "_", "x "},
 		{"DottedKey", "FOO.BAR=x", "FOO.BAR", "x"},
+		{"FwdSlashedKey", "FOO/BAR=x", "FOO/BAR", "x"},
 		{"README.md", `SOME_KEY = normal unquoted \text 'plus single quoted\' "\"double quoted " # EOL`, "SOME_KEY", `normal unquoted \text plus single quoted\ "double quoted `},
 		{"WindowsNewline", `w="\r\n"`, "w", "\r\n"},
 	}


### PR DESCRIPTION
adds support for '/' in keys (or support escaping in keys). This enables 1:1 compatibility with envconsul and the ability to import a tree of vars from consul without needing to replace the '/' with '_'.

Refers to: https://github.com/hashicorp/go-envparse/issues/3#issue-448227813