### PR TITLE
fix order issue for env expand

### DIFF
--- a/envparse.go
+++ b/envparse.go
@@ -57,10 +57,39 @@ func parseError(line int, err error) error {
 	}
 }
 
+type Pair struct {
+	Key string
+	Val string
+}
+
+type Pairs []Pair
+
+// Get returns the value associated with the given key, or "" if none exists.
+func (p Pairs) Get(key string) string {
+	for _, v := range p {
+		if v.Key == key {
+			return v.Val
+		}
+	}
+	return ""
+}
+
+// Set sets the key to value. It replaces any existing values.
+func (p *Pairs) Set(key, val string) {
+	for i, v := range *p {
+		if v.Key == key {
+			(*p)[i].Val = val
+			return
+		}
+	}
+
+	*p = append(*p, Pair{key, val})
+}
+
 // Parse environment variables from an io.Reader into a map or return a
 // ParseError.
-func Parse(r io.Reader) (map[string]string, error) {
-	env := make(map[string]string)
+func Parse(r io.Reader) (Pairs, error) {
+	env := Pairs{}
 	scanner := bufio.NewScanner(r)
 
 	// Track line number
@@ -76,7 +105,7 @@ func Parse(r io.Reader) (map[string]string, error) {
 
 		// Skip blank lines
 		if len(k) > 0 {
-			env[string(k)] = string(v)
+			env.Set(string(k), string(v))
 		}
 	}
 	if err := scanner.Err(); err != nil {

--- a/envparse_test.go
+++ b/envparse_test.go
@@ -24,14 +24,14 @@ FIRST="overwrite # original"  #...
 	if len(env) != 3 {
 		t.Fatalf("expected 3 keys but found %d: %#v", len(env), env)
 	}
-	if expected := "overwrite # original"; env["FIRST"] != expected {
-		t.Errorf("expected FIRST=%q but found %q", expected, env["FIRST"])
+	if expected := "overwrite # original"; env.Get("FIRST") != expected {
+		t.Errorf("expected FIRST=%q but found %q", expected, env.Get("FIRST"))
 	}
-	if env["_"] != "_" {
-		t.Errorf("expected _=_ but found: %q", env["_"])
+	if env.Get("_") != "_" {
+		t.Errorf("expected _=_ but found: %q", env.Get("_"))
 	}
-	if env["_2"] != "_2" {
-		t.Errorf("expected _2=_2 but found: %q", env["_2"])
+	if env.Get("_2") != "_2" {
+		t.Errorf("expected _2=_2 but found: %q", env.Get("_2"))
 	}
 }
 


### PR DESCRIPTION
For example if we have a .env file like:

```bash
A=1
B=${A}
C=${B}
```

When we want to iterate items in the go map the order will be random. There's no way we can guarantee the .env can be properly expanded.

The expect outcome:

```bash
A=1
B=1
C=1
```

But we may get:

```bash
A=1
B=""
C=""
```